### PR TITLE
Add advanced auth flows and user administration endpoints

### DIFF
--- a/db/migrations/002_core_tables.surql
+++ b/db/migrations/002_core_tables.surql
@@ -1,0 +1,260 @@
+USE NS app DB dashboard;
+
+-- Extend user schema
+DEFINE FIELD name ON TABLE user TYPE option<string>;
+DEFINE FIELD avatar ON TABLE user TYPE option<string>;
+DEFINE FIELD preferences ON TABLE user TYPE option<object>;
+DEFINE FIELD status ON TABLE user TYPE string DEFAULT "active";
+DEFINE FIELD deleted_at ON TABLE user TYPE option<datetime>;
+DEFINE FIELD totp_secret ON TABLE user TYPE option<string>;
+DEFINE FIELD totp_enabled ON TABLE user TYPE bool DEFAULT false;
+DEFINE FIELD backup_codes ON TABLE user TYPE option<array>;
+DEFINE FIELD email_verified ON TABLE user TYPE bool DEFAULT false;
+DEFINE FIELD last_login_at ON TABLE user TYPE option<datetime>;
+DEFINE FIELD profile_updated_at ON TABLE user TYPE option<datetime>;
+
+-- Roles
+DEFINE TABLE role SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin"
+    FOR create WHERE $auth.role = "admin"
+    FOR update WHERE $auth.role = "admin"
+    FOR delete WHERE $auth.role = "admin";
+DEFINE FIELD name ON TABLE role TYPE string;
+DEFINE FIELD description ON TABLE role TYPE option<string>;
+DEFINE FIELD permissions ON TABLE role TYPE array<string>;
+DEFINE FIELD created_at ON TABLE role TYPE datetime VALUE time::now();
+DEFINE FIELD updated_at ON TABLE role TYPE datetime VALUE time::now();
+DEFINE INDEX idx_role_name ON TABLE role COLUMNS name UNIQUE;
+
+-- Organizations
+DEFINE TABLE organization SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR array::contains(members, $auth.id)
+    FOR create WHERE $auth.role = "admin" OR true
+    FOR update WHERE $auth.role = "admin"
+    FOR delete WHERE $auth.role = "admin";
+DEFINE FIELD name ON TABLE organization TYPE string;
+DEFINE FIELD owner_id ON TABLE organization TYPE string;
+DEFINE FIELD members ON TABLE organization TYPE array<string> DEFAULT [];
+DEFINE FIELD created_at ON TABLE organization TYPE datetime VALUE time::now();
+DEFINE FIELD updated_at ON TABLE organization TYPE datetime VALUE time::now();
+
+-- Teams
+DEFINE TABLE team SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR create WHERE $auth.role = "admin" OR true
+    FOR update WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = owner_id;
+DEFINE FIELD name ON TABLE team TYPE string;
+DEFINE FIELD description ON TABLE team TYPE option<string>;
+DEFINE FIELD owner_id ON TABLE team TYPE string;
+DEFINE FIELD org_id ON TABLE team TYPE option<string>;
+DEFINE FIELD created_at ON TABLE team TYPE datetime VALUE time::now();
+DEFINE FIELD updated_at ON TABLE team TYPE datetime VALUE time::now();
+
+DEFINE TABLE team_member SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR create WHERE $auth.role = "admin"
+    FOR update WHERE $auth.role = "admin"
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = user_id;
+DEFINE FIELD team_id ON TABLE team_member TYPE string;
+DEFINE FIELD user_id ON TABLE team_member TYPE string;
+DEFINE FIELD role ON TABLE team_member TYPE string;
+DEFINE FIELD added_at ON TABLE team_member TYPE datetime VALUE time::now();
+DEFINE INDEX idx_team_member_unique ON TABLE team_member COLUMNS team_id, user_id UNIQUE;
+
+-- Projects
+DEFINE TABLE project SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR create WHERE $auth.role = "admin" OR true
+    FOR update WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = owner_id;
+DEFINE FIELD name ON TABLE project TYPE string;
+DEFINE FIELD description ON TABLE project TYPE option<string>;
+DEFINE FIELD status ON TABLE project TYPE string DEFAULT "active";
+DEFINE FIELD org_id ON TABLE project TYPE option<string>;
+DEFINE FIELD owner_id ON TABLE project TYPE string;
+DEFINE FIELD settings ON TABLE project TYPE option<object>;
+DEFINE FIELD created_at ON TABLE project TYPE datetime VALUE time::now();
+DEFINE FIELD updated_at ON TABLE project TYPE datetime VALUE time::now();
+DEFINE FIELD archived_at ON TABLE project TYPE option<datetime>;
+DEFINE INDEX idx_project_name ON TABLE project COLUMNS name;
+
+-- Tasks
+DEFINE TABLE task SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR create WHERE $auth.role = "admin" OR true
+    FOR update WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = owner_id;
+DEFINE FIELD title ON TABLE task TYPE string;
+DEFINE FIELD description ON TABLE task TYPE option<string>;
+DEFINE FIELD status ON TABLE task TYPE string DEFAULT "open";
+DEFINE FIELD project_id ON TABLE task TYPE string;
+DEFINE FIELD owner_id ON TABLE task TYPE string;
+DEFINE FIELD metadata ON TABLE task TYPE option<object>;
+DEFINE FIELD created_at ON TABLE task TYPE datetime VALUE time::now();
+DEFINE FIELD updated_at ON TABLE task TYPE datetime VALUE time::now();
+
+DEFINE TABLE task_assignment SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR create WHERE $auth.role = "admin"
+    FOR update WHERE $auth.role = "admin"
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = user_id;
+DEFINE FIELD task_id ON TABLE task_assignment TYPE string;
+DEFINE FIELD user_id ON TABLE task_assignment TYPE string;
+DEFINE FIELD added_at ON TABLE task_assignment TYPE datetime VALUE time::now();
+DEFINE INDEX idx_task_assignment_unique ON TABLE task_assignment COLUMNS task_id, user_id UNIQUE;
+
+-- Audit logs
+DEFINE TABLE audit_log SCHEMALESS
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin"
+    FOR create WHERE true;
+DEFINE INDEX idx_audit_resource ON TABLE audit_log COLUMNS resource_type, resource_id;
+
+-- Notifications
+DEFINE TABLE notification SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR create WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR update WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = user_id;
+DEFINE FIELD user_id ON TABLE notification TYPE string;
+DEFINE FIELD subject ON TABLE notification TYPE string;
+DEFINE FIELD body ON TABLE notification TYPE option<string>;
+DEFINE FIELD read ON TABLE notification TYPE bool DEFAULT false;
+DEFINE FIELD read_at ON TABLE notification TYPE option<datetime>;
+DEFINE FIELD created_at ON TABLE notification TYPE datetime VALUE time::now();
+
+-- API keys
+DEFINE TABLE api_key SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR create WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR update WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = user_id;
+DEFINE FIELD user_id ON TABLE api_key TYPE string;
+DEFINE FIELD name ON TABLE api_key TYPE string;
+DEFINE FIELD token_prefix ON TABLE api_key TYPE string;
+DEFINE FIELD token_hash ON TABLE api_key TYPE string;
+DEFINE FIELD scopes ON TABLE api_key TYPE option<array<string>>;
+DEFINE FIELD created_at ON TABLE api_key TYPE datetime VALUE time::now();
+DEFINE FIELD last_used_at ON TABLE api_key TYPE option<datetime>;
+DEFINE FIELD expires_at ON TABLE api_key TYPE option<datetime>;
+DEFINE FIELD revoked ON TABLE api_key TYPE bool DEFAULT false;
+DEFINE INDEX idx_api_key_prefix ON TABLE api_key COLUMNS token_prefix UNIQUE;
+
+-- Webhooks
+DEFINE TABLE webhook SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR create WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR update WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = owner_id;
+DEFINE FIELD owner_id ON TABLE webhook TYPE string;
+DEFINE FIELD org_id ON TABLE webhook TYPE option<string>;
+DEFINE FIELD name ON TABLE webhook TYPE string;
+DEFINE FIELD url ON TABLE webhook TYPE string;
+DEFINE FIELD events ON TABLE webhook TYPE array<string>;
+DEFINE FIELD secret ON TABLE webhook TYPE string;
+DEFINE FIELD active ON TABLE webhook TYPE bool DEFAULT true;
+DEFINE FIELD created_at ON TABLE webhook TYPE datetime VALUE time::now();
+DEFINE FIELD updated_at ON TABLE webhook TYPE datetime VALUE time::now();
+
+-- Files
+DEFINE TABLE file_asset SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR create WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR update WHERE $auth.role = "admin" OR $auth.id = owner_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = owner_id;
+DEFINE FIELD owner_id ON TABLE file_asset TYPE string;
+DEFINE FIELD filename ON TABLE file_asset TYPE string;
+DEFINE FIELD content_type ON TABLE file_asset TYPE option<string>;
+DEFINE FIELD size ON TABLE file_asset TYPE int;
+DEFINE FIELD path ON TABLE file_asset TYPE string;
+DEFINE FIELD metadata ON TABLE file_asset TYPE option<object>;
+DEFINE FIELD created_at ON TABLE file_asset TYPE datetime VALUE time::now();
+
+-- Refresh tokens
+DEFINE TABLE refresh_token SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR create WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR update WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = user_id;
+DEFINE FIELD user_id ON TABLE refresh_token TYPE string;
+DEFINE FIELD session_id ON TABLE refresh_token TYPE string;
+DEFINE FIELD token_hash ON TABLE refresh_token TYPE string;
+DEFINE FIELD active ON TABLE refresh_token TYPE bool DEFAULT true;
+DEFINE FIELD created_at ON TABLE refresh_token TYPE datetime VALUE time::now();
+DEFINE FIELD expires_at ON TABLE refresh_token TYPE datetime;
+DEFINE FIELD rotated_at ON TABLE refresh_token TYPE option<datetime>;
+DEFINE INDEX idx_refresh_token_hash ON TABLE refresh_token COLUMNS token_hash;
+
+-- Password reset tokens
+DEFINE TABLE password_reset SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin"
+    FOR create WHERE true
+    FOR update WHERE true
+    FOR delete WHERE true;
+DEFINE FIELD user_id ON TABLE password_reset TYPE string;
+DEFINE FIELD token_hash ON TABLE password_reset TYPE string;
+DEFINE FIELD expires_at ON TABLE password_reset TYPE datetime;
+DEFINE FIELD used ON TABLE password_reset TYPE bool DEFAULT false;
+DEFINE FIELD created_at ON TABLE password_reset TYPE datetime VALUE time::now();
+DEFINE INDEX idx_password_reset_token ON TABLE password_reset COLUMNS token_hash;
+
+-- Email verification codes
+DEFINE TABLE email_verification SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin"
+    FOR create WHERE true
+    FOR update WHERE true
+    FOR delete WHERE true;
+DEFINE FIELD user_id ON TABLE email_verification TYPE string;
+DEFINE FIELD code_hash ON TABLE email_verification TYPE string;
+DEFINE FIELD expires_at ON TABLE email_verification TYPE datetime;
+DEFINE FIELD used ON TABLE email_verification TYPE bool DEFAULT false;
+DEFINE FIELD created_at ON TABLE email_verification TYPE datetime VALUE time::now();
+DEFINE INDEX idx_email_verification_code ON TABLE email_verification COLUMNS code_hash;
+
+-- Sessions
+DEFINE TABLE session SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR create WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR update WHERE $auth.role = "admin" OR $auth.id = user_id
+    FOR delete WHERE $auth.role = "admin" OR $auth.id = user_id;
+DEFINE FIELD user_id ON TABLE session TYPE string;
+DEFINE FIELD user_agent ON TABLE session TYPE option<string>;
+DEFINE FIELD ip_address ON TABLE session TYPE option<string>;
+DEFINE FIELD created_at ON TABLE session TYPE datetime VALUE time::now();
+DEFINE FIELD last_seen_at ON TABLE session TYPE datetime VALUE time::now();
+DEFINE FIELD revoked ON TABLE session TYPE bool DEFAULT false;
+DEFINE INDEX idx_session_user ON TABLE session COLUMNS user_id;
+
+-- Invitations
+DEFINE TABLE invite SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE $auth.role = "admin"
+    FOR create WHERE $auth.role = "admin"
+    FOR update WHERE $auth.role = "admin"
+    FOR delete WHERE $auth.role = "admin";
+DEFINE FIELD email ON TABLE invite TYPE string;
+DEFINE FIELD invited_by ON TABLE invite TYPE string;
+DEFINE FIELD token_hash ON TABLE invite TYPE string;
+DEFINE FIELD status ON TABLE invite TYPE string DEFAULT "pending";
+DEFINE FIELD created_at ON TABLE invite TYPE datetime VALUE time::now();
+DEFINE INDEX idx_invite_email ON TABLE invite COLUMNS email;
+
+-- Search helper index for tasks
+DEFINE INDEX idx_task_title ON TABLE task COLUMNS title;
+

--- a/src/controllers/AuthController.cc
+++ b/src/controllers/AuthController.cc
@@ -3,139 +3,764 @@
 #include "../db/SurrealClient.h"
 #include "../utils/crypto.hpp"
 #include "../utils/jwt.hpp"
+#include "../utils/totp.hpp"
+#include "../utils/logging.hpp"
+#include <optional>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <algorithm>
+#include <ctime>
 
 using namespace drogon;
 
-static std::string toLowerTrim(std::string s){
-    // trim
-    auto isspace2 = [](unsigned char c){return std::isspace(c);};
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [&](unsigned char c){return !isspace2(c);}));
-    s.erase(std::find_if(s.rbegin(), s.rend(), [&](unsigned char c){return !isspace2(c);}).base(), s.end());
-    // lower
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c){return std::tolower(c);});
+namespace {
+std::string toLowerTrim(std::string s) {
+    auto isspace2 = [](unsigned char c) { return std::isspace(c); };
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [&](unsigned char c) { return !isspace2(c); }));
+    s.erase(std::find_if(s.rbegin(), s.rend(), [&](unsigned char c) { return !isspace2(c); }).base(), s.end());
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
     return s;
 }
 
-void AuthController::registerUser(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) {
+std::string isoTime(std::chrono::system_clock::time_point tp) {
+    auto tt = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm{};
+#if defined(_WIN32)
+    gmtime_s(&tm, &tt);
+#else
+    gmtime_r(&tt, &tm);
+#endif
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+    return oss.str();
+}
+
+std::string recordIdPart(const std::string& rid) {
+    auto pos = rid.find(':');
+    if (pos == std::string::npos) {
+        return rid;
+    }
+    return rid.substr(pos + 1);
+}
+
+Json::Value sanitizeUser(Json::Value user) {
+    user.removeMember("password_hash");
+    user.removeMember("totp_secret");
+    user.removeMember("backup_codes");
+    return user;
+}
+
+void audit(SurrealClient& db,
+           const std::string& userId,
+           const std::string& action,
+           const std::string& resourceType,
+           const std::string& resourceId,
+           const Json::Value& metadata = Json::Value(Json::objectValue)) {
+    Json::Value metaCopy = metadata;
+    db.recordAudit(userId, action, resourceType, resourceId, metaCopy);
+}
+
+std::string peerIp(const HttpRequestPtr& req) {
+    auto forwarded = req->getHeader("X-Forwarded-For");
+    if (!forwarded.empty()) {
+        auto pos = forwarded.find(',');
+        std::string candidate = forwarded.substr(0, pos);
+        candidate.erase(0, candidate.find_first_not_of(" \t"));
+        candidate.erase(candidate.find_last_not_of(" \t") + 1);
+        return candidate;
+    }
+    try {
+        return req->getPeerAddr().toIp();
+    } catch (...) {
+        return "";
+    }
+}
+
+std::string methodName(const HttpRequestPtr& req) {
+    switch (req->getMethod()) {
+        case Get: return "GET";
+        case Post: return "POST";
+        case Put: return "PUT";
+        case Delete: return "DELETE";
+        case Patch: return "PATCH";
+        default: return "NONE";
+    }
+}
+
+bool consumeBackupCode(SurrealClient& db, Json::Value& user, const std::string& code) {
+    if (!user.isMember("backup_codes") || !user["backup_codes"].isArray()) {
+        return false;
+    }
+    Json::Value remaining(Json::arrayValue);
+    bool matched = false;
+    for (const auto& entry : user["backup_codes"]) {
+        std::string stored = entry.asString();
+        if (!matched && crypto::verify_password_pbkdf2(code, stored)) {
+            matched = true;
+            continue;
+        }
+        remaining.append(stored);
+    }
+    if (matched) {
+        Json::Value update;
+        update["backup_codes"] = remaining;
+        db.updateRecord("user", recordIdPart(user["id"].asString()), update);
+        user["backup_codes"] = remaining;
+    }
+    return matched;
+}
+
+std::string base64Url(const std::string& input) {
+    auto encoded = drogon::utils::base64Encode(input);
+    encoded.erase(std::remove(encoded.begin(), encoded.end(), '='), encoded.end());
+    std::replace(encoded.begin(), encoded.end(), '+', '-');
+    std::replace(encoded.begin(), encoded.end(), '/', '_');
+    return encoded;
+}
+
+Json::Value issueTokens(SurrealClient& db,
+                        Json::Value user,
+                        const HttpRequestPtr& req,
+                        const std::optional<std::string>& existingSession = std::nullopt,
+                        bool updateLogin = false) {
+    auto now = std::chrono::system_clock::now();
+    std::string sessionRecordId;
+    if (existingSession.has_value()) {
+        sessionRecordId = *existingSession;
+        Json::Value update;
+        update["last_seen_at"] = isoTime(now);
+        db.updateRecord("session", recordIdPart(sessionRecordId), update);
+    } else {
+        Json::Value session;
+        session["user_id"] = user["id"].asString();
+        auto ua = req->getHeader("User-Agent");
+        if (!ua.empty()) {
+            session["user_agent"] = ua;
+        }
+        auto ip = peerIp(req);
+        if (!ip.empty()) {
+            session["ip_address"] = ip;
+        }
+        auto created = db.createRecord("session", drogon::utils::getUuid(), session);
+        sessionRecordId = created["id"].asString();
+    }
+
+    auto accessLifetime = std::chrono::seconds(3600 * 12);
+    auto refreshLifetime = std::chrono::hours(24 * 14);
+
+    Json::Value claims;
+    claims["sub"] = user["id"].asString();
+    claims["email"] = user.get("email", "").asString();
+    claims["role"] = user.get("role", "user").asString();
+    claims["iat"] = static_cast<Json::Int64>(std::time(nullptr));
+    claims["exp"] = static_cast<Json::Int64>(std::time(nullptr) + accessLifetime.count());
+    claims["jti"] = drogon::utils::getUuid();
+    claims["sid"] = sessionRecordId;
+
+    const char* sec = std::getenv("JWT_SECRET");
+    std::string secret = sec ? sec : "change_me_dev_secret";
+    auto accessToken = jwt::create_hs256(claims, secret);
+
+    std::string refreshPlain = crypto::random_token_hex(32);
+    Json::Value refreshPayload;
+    refreshPayload["user_id"] = user["id"].asString();
+    refreshPayload["session_id"] = sessionRecordId;
+    refreshPayload["token_hash"] = crypto::sha256_hex(refreshPlain);
+    refreshPayload["active"] = true;
+    refreshPayload["expires_at"] = isoTime(now + refreshLifetime);
+    db.createRecord("refresh_token", drogon::utils::getUuid(), refreshPayload);
+
+    if (updateLogin) {
+        Json::Value update;
+        update["last_login_at"] = isoTime(now);
+        db.updateRecord("user", recordIdPart(user["id"].asString()), update);
+    }
+
+    logging::info("AuthController.cc", "AuthController", "issueTokens", "auth", __LINE__, "issued tokens", methodName(req));
+
+    Json::Value out;
+    out["access_token"] = accessToken;
+    out["refresh_token"] = refreshPlain;
+    out["expires_in"] = static_cast<Json::Int64>(accessLifetime.count());
+    out["refresh_token_expires_at"] = refreshPayload["expires_at"];
+    out["session_id"] = sessionRecordId;
+    out["user"] = sanitizeUser(user);
+    return out;
+}
+
+} // namespace
+
+void AuthController::registerUser(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
     auto json = req->getJsonObject();
     if (!json || !(*json).isMember("email") || !(*json).isMember("password")) {
-        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","email and password required"} });
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "email and password required"}});
         resp->setStatusCode(k400BadRequest);
         return callback(resp);
     }
+
     auto email = (*json)["email"].asString();
-    auto pass  = (*json)["password"].asString();
+    auto pass = (*json)["password"].asString();
     if (pass.size() < 8) {
-        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","password too short"} });
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "password too short"}});
         resp->setStatusCode(k400BadRequest);
         return callback(resp);
     }
+
     try {
         SurrealClient db;
         auto emailNorm = toLowerTrim(email);
         auto existing = db.selectOneByEmail(emailNorm);
         if (!existing.isNull()) {
-            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","email already exists"} });
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "email already exists"}});
             resp->setStatusCode(k409Conflict);
             return callback(resp);
         }
-        auto hash = crypto::hash_password_pbkdf2(pass);
-        auto user = db.createUser(email, emailNorm, hash, "admin"); // first user can be admin in dev
-        // token
-        Json::Value claims;
-        claims["sub"] = user["id"].asString();
-        claims["email"] = emailNorm;
-        claims["role"] = user.get("role","user").asString();
-        claims["iat"] = (Json::Int64)std::time(nullptr);
-        claims["exp"] = (Json::Int64)(std::time(nullptr) + 3600*12);
-        claims["jti"] = drogon::utils::getUuid().c_str();
-        const char* sec = std::getenv("JWT_SECRET");
-        std::string secret = sec ? sec : "change_me_dev_secret";
-        auto token = jwt::create_hs256(claims, secret);
 
-        Json::Value out;
-        out["token"] = token;
-        out["user"] = user;
-        auto resp = HttpResponse::newHttpJsonResponse(out);
+        bool firstUser = false;
+        try {
+            auto countRes = db.exec("SELECT count() AS total FROM user;");
+            if (countRes.isArray() && !countRes.empty() && countRes[0]["result"].isArray() && !countRes[0]["result"].empty()) {
+                firstUser = countRes[0]["result"][0]["total"].asInt64() == 0;
+            }
+        } catch (...) {
+            firstUser = false;
+        }
+
+        auto hash = crypto::hash_password_pbkdf2(pass);
+        auto user = db.createUser(email, emailNorm, hash, firstUser ? "admin" : "user");
+        Json::Value update;
+        update["email_verified"] = false;
+        update["status"] = "active";
+        db.updateRecord("user", recordIdPart(user["id"].asString()), update);
+        user = db.selectById("user", recordIdPart(user["id"].asString()));
+
+        auto verificationCode = crypto::random_token_hex(16);
+        Json::Value verification;
+        verification["user_id"] = user["id"].asString();
+        verification["code_hash"] = crypto::sha256_hex(verificationCode);
+        verification["expires_at"] = isoTime(std::chrono::system_clock::now() + std::chrono::hours(24));
+        db.createRecord("email_verification", drogon::utils::getUuid(), verification);
+
+        auto tokens = issueTokens(db, user, req, std::nullopt, true);
+        tokens["verification_code"] = verificationCode;
+
+        audit(db, user["id"].asString(), "register", "user", user["id"].asString(), Json::Value{{"email", emailNorm}});
+
+        auto resp = HttpResponse::newHttpJsonResponse(tokens);
+        resp->setStatusCode(k201Created);
         callback(resp);
     } catch (const std::exception& e) {
-        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","registration failed"} });
+        logging::error("AuthController.cc", "AuthController", "registerUser", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "registration failed"}});
         resp->setStatusCode(k500InternalServerError);
         callback(resp);
     }
 }
 
-void AuthController::login(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) {
+void AuthController::login(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
     auto json = req->getJsonObject();
     if (!json || !(*json).isMember("email") || !(*json).isMember("password")) {
-        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","email and password required"} });
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "email and password required"}});
         resp->setStatusCode(k400BadRequest);
         return callback(resp);
     }
+
     auto emailNorm = toLowerTrim((*json)["email"].asString());
     auto pass = (*json)["password"].asString();
+
     try {
         SurrealClient db;
         auto user = db.selectOneByEmail(emailNorm);
         if (user.isNull()) {
-            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","invalid credentials"} });
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid credentials"}});
             resp->setStatusCode(k401Unauthorized);
             return callback(resp);
         }
-        auto stored = user.get("password_hash","").asString();
-        if (!crypto::verify_password_pbkdf2(pass, stored)) {
-            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","invalid credentials"} });
-            resp->setStatusCode(k401Unauthorized);
+        if (user.get("status", "active").asString() != "active") {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "account disabled"}});
+            resp->setStatusCode(k403Forbidden);
             return callback(resp);
         }
-        Json::Value claims;
-        claims["sub"] = user["id"].asString();
-        claims["email"] = emailNorm;
-        claims["role"] = user.get("role","user").asString();
-        claims["iat"] = (Json::Int64)std::time(nullptr);
-        claims["exp"] = (Json::Int64)(std::time(nullptr) + 3600*12);
-        claims["jti"] = drogon::utils::getUuid().c_str();
-        const char* sec = std::getenv("JWT_SECRET");
-        std::string secret = sec ? sec : "change_me_dev_secret";
-        auto token = jwt::create_hs256(claims, secret);
 
-        Json::Value out;
-        out["token"] = token;
-        out["user"] = user;
-        auto resp = HttpResponse::newHttpJsonResponse(out);
+        auto stored = user.get("password_hash", "").asString();
+        if (!crypto::verify_password_pbkdf2(pass, stored)) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid credentials"}});
+            resp->setStatusCode(k401Unauthorized);
+            return callback(resp);
+        }
+
+        bool totpEnabled = user.get("totp_enabled", false).asBool();
+        if (totpEnabled) {
+            std::string totpCode = (*json).get("totp", "").asString();
+            std::string backup = (*json).get("backup_code", "").asString();
+            bool ok = false;
+            auto secret = user.get("totp_secret", "").asString();
+            if (!secret.empty() && !totpCode.empty()) {
+                ok = totp::verify_code(secret, totpCode);
+            }
+            if (!ok && !backup.empty()) {
+                ok = consumeBackupCode(db, user, backup);
+            }
+            if (!ok) {
+                auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "totp required"}});
+                resp->setStatusCode(k401Unauthorized);
+                return callback(resp);
+            }
+        }
+
+        auto tokens = issueTokens(db, user, req, std::nullopt, true);
+        audit(db, user["id"].asString(), "login", "session", tokens["session_id"].asString(), Json::Value{{"ip", peerIp(req)}});
+
+        auto resp = HttpResponse::newHttpJsonResponse(tokens);
         callback(resp);
     } catch (const std::exception& e) {
-        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","login failed"} });
+        logging::error("AuthController.cc", "AuthController", "login", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "login failed"}});
         resp->setStatusCode(k500InternalServerError);
         callback(resp);
     }
 }
 
-void AuthController::logout(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) {
-    // Add jti to blacklist with TTL
+void AuthController::logout(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
     auto attrs = req->getAttributes();
     if (!attrs->find("claims")) {
-        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","no claims"} });
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "no claims"}});
         resp->setStatusCode(k401Unauthorized);
         return callback(resp);
     }
     Json::Value claims = attrs->get<Json::Value>("claims");
-    auto jti = claims.get("jti","").asString();
-    auto exp = claims.get("exp", (Json::Int64)std::time(nullptr)).asInt64();
-    auto now = (Json::Int64)std::time(nullptr);
-    auto ttl = (int)std::max<Json::Int64>(0, exp - now);
+    auto jti = claims.get("jti", "").asString();
+    auto exp = claims.get("exp", static_cast<Json::Int64>(std::time(nullptr))).asInt64();
+    auto now = static_cast<Json::Int64>(std::time(nullptr));
+    auto ttl = static_cast<int>(std::max<Json::Int64>(0, exp - now));
 
-    auto redis = app().getRedisClient();
-    redis->execCommandAsync(
-        [callback](const drogon::nosql::RedisResult &){ 
-            auto resp = HttpResponse::newHttpResponse();
-            resp->setStatusCode(k204NoContent);
-            callback(resp);
-        },
-        [callback](const std::exception &e){
-            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","redis error"} });
-            resp->setStatusCode(k500InternalServerError);
-            callback(resp);
-        },
-        "SETEX blacklist:jti:%s %d 1", jti.c_str(), ttl);
+    try {
+        auto redis = app().getRedisClient();
+        redis->execCommandAsync(
+            [callback](const drogon::nosql::RedisResult &) {
+                auto resp = HttpResponse::newHttpResponse();
+                resp->setStatusCode(k204NoContent);
+                callback(resp);
+            },
+            [callback](const std::exception &) {
+                auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "redis error"}});
+                resp->setStatusCode(k500InternalServerError);
+                callback(resp);
+            },
+            "SETEX blacklist:jti:%s %d 1", jti.c_str(), ttl);
+
+        SurrealClient db;
+        auto sessionId = claims.get("sid", "").asString();
+        if (!sessionId.empty()) {
+            Json::Value update;
+            update["revoked"] = true;
+            update["last_seen_at"] = isoTime(std::chrono::system_clock::now());
+            db.updateRecord("session", recordIdPart(sessionId), update);
+            std::stringstream ss;
+            ss << "UPDATE refresh_token SET active = false, rotated_at = time::now() WHERE session_id = '" << sessionId << "';";
+            db.exec(ss.str());
+            audit(db, claims.get("sub", "").asString(), "logout", "session", sessionId, Json::Value());
+        }
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "logout", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "logout failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void AuthController::refresh(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    auto json = req->getJsonObject();
+    if (!json || !(*json).isMember("refresh_token")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "refresh_token required"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+    auto token = (*json)["refresh_token"].asString();
+    if (token.empty()) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid refresh token"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+
+    try {
+        SurrealClient db;
+        auto hash = crypto::sha256_hex(token);
+        std::stringstream ss;
+        ss << "LET $hash := '" << hash << "';";
+        ss << "SELECT * FROM refresh_token WHERE token_hash = $hash AND active = true AND expires_at > time::now() LIMIT 1;";
+        auto res = db.exec(ss.str());
+        auto tokenRecord = db.firstResult(res);
+        if (tokenRecord.isNull()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "refresh expired"}});
+            resp->setStatusCode(k401Unauthorized);
+            return callback(resp);
+        }
+        auto sessionId = tokenRecord.get("session_id", "").asString();
+        auto session = db.selectById("session", recordIdPart(sessionId));
+        if (session.isNull() || session.get("revoked", false).asBool()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "session revoked"}});
+            resp->setStatusCode(k401Unauthorized);
+            return callback(resp);
+        }
+        auto userId = tokenRecord.get("user_id", "").asString();
+        auto user = db.selectById("user", recordIdPart(userId));
+        if (user.isNull() || user.get("status", "active").asString() != "active") {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "account disabled"}});
+            resp->setStatusCode(k401Unauthorized);
+            return callback(resp);
+        }
+
+        Json::Value update;
+        update["active"] = false;
+        update["rotated_at"] = isoTime(std::chrono::system_clock::now());
+        db.updateRecord("refresh_token", recordIdPart(tokenRecord["id"].asString()), update);
+
+        auto tokens = issueTokens(db, user, req, sessionId, false);
+        audit(db, userId, "refresh", "session", sessionId, Json::Value());
+
+        auto resp = HttpResponse::newHttpJsonResponse(tokens);
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "refresh", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "refresh failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void AuthController::forgotPassword(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    auto json = req->getJsonObject();
+    if (!json || !(*json).isMember("email")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+        resp->setStatusCode(k200OK);
+        return callback(resp);
+    }
+    auto emailNorm = toLowerTrim((*json)["email"].asString());
+
+    try {
+        SurrealClient db;
+        auto user = db.selectOneByEmail(emailNorm);
+        std::string resetToken;
+        if (!user.isNull()) {
+            resetToken = crypto::random_token_hex(16);
+            Json::Value reset;
+            reset["user_id"] = user["id"].asString();
+            reset["token_hash"] = crypto::sha256_hex(resetToken);
+            reset["expires_at"] = isoTime(std::chrono::system_clock::now() + std::chrono::hours(1));
+            db.createRecord("password_reset", drogon::utils::getUuid(), reset);
+            audit(db, user["id"].asString(), "password_forgot", "user", user["id"].asString(), Json::Value());
+        }
+        Json::Value out;
+        out["status"] = "ok";
+        if (!resetToken.empty()) {
+            out["reset_token"] = resetToken;
+        }
+        auto resp = HttpResponse::newHttpJsonResponse(out);
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "forgotPassword", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void AuthController::resetPassword(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    auto json = req->getJsonObject();
+    if (!json || !(*json).isMember("token") || !(*json).isMember("password")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "token and password required"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+
+    auto token = (*json)["token"].asString();
+    auto password = (*json)["password"].asString();
+    if (password.size() < 8) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "password too short"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+
+    try {
+        SurrealClient db;
+        auto hash = crypto::sha256_hex(token);
+        std::stringstream ss;
+        ss << "LET $hash := '" << hash << "';";
+        ss << "SELECT * FROM password_reset WHERE token_hash = $hash AND used = false AND expires_at > time::now() LIMIT 1;";
+        auto res = db.exec(ss.str());
+        auto resetRecord = db.firstResult(res);
+        if (resetRecord.isNull()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid token"}});
+            resp->setStatusCode(k400BadRequest);
+            return callback(resp);
+        }
+
+        auto userId = resetRecord.get("user_id", "").asString();
+        Json::Value update;
+        update["password_hash"] = crypto::hash_password_pbkdf2(password);
+        update["profile_updated_at"] = isoTime(std::chrono::system_clock::now());
+        db.updateRecord("user", recordIdPart(userId), update);
+
+        Json::Value mark;
+        mark["used"] = true;
+        db.updateRecord("password_reset", recordIdPart(resetRecord["id"].asString()), mark);
+
+        std::stringstream revoke;
+        revoke << "UPDATE refresh_token SET active = false, rotated_at = time::now() WHERE user_id = '" << userId << "';";
+        db.exec(revoke.str());
+
+        audit(db, userId, "password_reset", "user", userId, Json::Value());
+
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "resetPassword", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "reset failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void AuthController::verifyEmail(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    auto json = req->getJsonObject();
+    if (!json || !(*json).isMember("code")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "code required"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+    auto code = (*json)["code"].asString();
+
+    try {
+        SurrealClient db;
+        auto hash = crypto::sha256_hex(code);
+        std::stringstream ss;
+        ss << "LET $hash := '" << hash << "';";
+        ss << "SELECT * FROM email_verification WHERE code_hash = $hash AND used = false AND expires_at > time::now() LIMIT 1;";
+        auto res = db.exec(ss.str());
+        auto record = db.firstResult(res);
+        if (record.isNull()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid code"}});
+            resp->setStatusCode(k400BadRequest);
+            return callback(resp);
+        }
+        auto userId = record.get("user_id", "").asString();
+        Json::Value update;
+        update["email_verified"] = true;
+        db.updateRecord("user", recordIdPart(userId), update);
+
+        Json::Value mark;
+        mark["used"] = true;
+        db.updateRecord("email_verification", recordIdPart(record["id"].asString()), mark);
+
+        audit(db, userId, "verify_email", "user", userId, Json::Value());
+
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "verifyEmail", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "verify failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void AuthController::jwks(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    const char* sec = std::getenv("JWT_SECRET");
+    std::string secret = sec ? sec : "change_me_dev_secret";
+    auto kid = crypto::sha256_hex(secret).substr(0, 16);
+    Json::Value key;
+    key["kty"] = "oct";
+    key["kid"] = kid;
+    key["k"] = base64Url(secret);
+    key["alg"] = "HS256";
+    key["use"] = "sig";
+    Json::Value jwks;
+    jwks["keys"].append(key);
+    auto resp = HttpResponse::newHttpJsonResponse(jwks);
+    callback(resp);
+}
+
+void AuthController::totpEnable(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    auto attrs = req->getAttributes();
+    if (!attrs->find("claims")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "no claims"}});
+        resp->setStatusCode(k401Unauthorized);
+        return callback(resp);
+    }
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    try {
+        SurrealClient db;
+        auto user = db.selectById("user", recordIdPart(claims.get("sub", "").asString()));
+        if (user.isNull()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "user not found"}});
+            resp->setStatusCode(k404NotFound);
+            return callback(resp);
+        }
+        auto secret = totp::generate_secret();
+        Json::Value update;
+        update["totp_secret"] = secret;
+        update["totp_enabled"] = false;
+        db.updateRecord("user", recordIdPart(user["id"].asString()), update);
+        auto uri = totp::otpauth_uri("DragonBreath", user.get("email", "user").asString(), secret);
+        audit(db, user["id"].asString(), "totp_enable_start", "user", user["id"].asString(), Json::Value());
+        Json::Value out;
+        out["secret"] = secret;
+        out["otpauth"] = uri;
+        auto resp = HttpResponse::newHttpJsonResponse(out);
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "totpEnable", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "enable failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void AuthController::totpVerify(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    auto attrs = req->getAttributes();
+    if (!attrs->find("claims")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "no claims"}});
+        resp->setStatusCode(k401Unauthorized);
+        return callback(resp);
+    }
+    auto json = req->getJsonObject();
+    if (!json || !(*json).isMember("code")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "code required"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+    auto code = (*json)["code"].asString();
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    try {
+        SurrealClient db;
+        auto user = db.selectById("user", recordIdPart(claims.get("sub", "").asString()));
+        if (user.isNull()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "user not found"}});
+            resp->setStatusCode(k404NotFound);
+            return callback(resp);
+        }
+        auto secret = user.get("totp_secret", "").asString();
+        if (secret.empty() || !totp::verify_code(secret, code)) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid code"}});
+            resp->setStatusCode(k400BadRequest);
+            return callback(resp);
+        }
+        Json::Value update;
+        update["totp_enabled"] = true;
+        db.updateRecord("user", recordIdPart(user["id"].asString()), update);
+        audit(db, user["id"].asString(), "totp_verified", "user", user["id"].asString(), Json::Value());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "totpVerify", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "verify failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void AuthController::totpDisable(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    auto attrs = req->getAttributes();
+    if (!attrs->find("claims")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "no claims"}});
+        resp->setStatusCode(k401Unauthorized);
+        return callback(resp);
+    }
+    auto json = req->getJsonObject();
+    std::string code = json ? (*json).get("code", "").asString() : "";
+    std::string backup = json ? (*json).get("backup_code", "").asString() : "";
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    try {
+        SurrealClient db;
+        auto user = db.selectById("user", recordIdPart(claims.get("sub", "").asString()));
+        if (user.isNull()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "user not found"}});
+            resp->setStatusCode(k404NotFound);
+            return callback(resp);
+        }
+        if (!user.get("totp_enabled", false).asBool()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+            return callback(resp);
+        }
+        bool ok = false;
+        auto secret = user.get("totp_secret", "").asString();
+        if (!secret.empty() && !code.empty()) {
+            ok = totp::verify_code(secret, code);
+        }
+        if (!ok && !backup.empty()) {
+            ok = consumeBackupCode(db, user, backup);
+        }
+        if (!ok) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "verification required"}});
+            resp->setStatusCode(k401Unauthorized);
+            return callback(resp);
+        }
+        Json::Value update;
+        update["totp_secret"] = Json::Value(Json::nullValue);
+        update["totp_enabled"] = false;
+        update["backup_codes"] = Json::Value(Json::arrayValue);
+        db.updateRecord("user", recordIdPart(user["id"].asString()), update);
+        audit(db, user["id"].asString(), "totp_disabled", "user", user["id"].asString(), Json::Value());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "totpDisable", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "disable failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void AuthController::backupCodes(const HttpRequestPtr& req, std::function<void(const HttpResponsePtr&)> &&callback) {
+    auto attrs = req->getAttributes();
+    if (!attrs->find("claims")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "no claims"}});
+        resp->setStatusCode(k401Unauthorized);
+        return callback(resp);
+    }
+    auto json = req->getJsonObject();
+    std::string code = json ? (*json).get("code", "").asString() : "";
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    try {
+        SurrealClient db;
+        auto user = db.selectById("user", recordIdPart(claims.get("sub", "").asString()));
+        if (user.isNull()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "user not found"}});
+            resp->setStatusCode(k404NotFound);
+            return callback(resp);
+        }
+        if (!user.get("totp_enabled", false).asBool()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "totp not enabled"}});
+            resp->setStatusCode(k400BadRequest);
+            return callback(resp);
+        }
+        auto secret = user.get("totp_secret", "").asString();
+        if (secret.empty() || !totp::verify_code(secret, code)) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "verification required"}});
+            resp->setStatusCode(k401Unauthorized);
+            return callback(resp);
+        }
+        Json::Value codes(Json::arrayValue);
+        Json::Value hashed(Json::arrayValue);
+        for (int i = 0; i < 8; ++i) {
+            auto c = crypto::random_alphanum(10);
+            codes.append(c);
+            hashed.append(crypto::hash_password_pbkdf2(c));
+        }
+        Json::Value update;
+        update["backup_codes"] = hashed;
+        db.updateRecord("user", recordIdPart(user["id"].asString()), update);
+        audit(db, user["id"].asString(), "backup_codes", "user", user["id"].asString(), Json::Value());
+        Json::Value out;
+        out["codes"] = codes;
+        auto resp = HttpResponse::newHttpJsonResponse(out);
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("AuthController.cc", "AuthController", "backupCodes", "auth", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "generation failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
 }

--- a/src/controllers/AuthController.h
+++ b/src/controllers/AuthController.h
@@ -7,9 +7,27 @@ public:
     ADD_METHOD_TO(AuthController::registerUser, "/api/auth/register", drogon::Post);
     ADD_METHOD_TO(AuthController::login, "/api/auth/login", drogon::Post);
     ADD_METHOD_TO(AuthController::logout, "/api/auth/logout", drogon::Post, "AuthFilter");
+    ADD_METHOD_TO(AuthController::refresh, "/api/auth/refresh", drogon::Post);
+    ADD_METHOD_TO(AuthController::forgotPassword, "/api/auth/forgot-password", drogon::Post);
+    ADD_METHOD_TO(AuthController::resetPassword, "/api/auth/reset-password", drogon::Post);
+    ADD_METHOD_TO(AuthController::verifyEmail, "/api/auth/verify-email", drogon::Post);
+    ADD_METHOD_TO(AuthController::jwks, "/api/auth/jwks", drogon::Get);
+    ADD_METHOD_TO(AuthController::totpEnable, "/api/auth/totp/enable", drogon::Post, "AuthFilter");
+    ADD_METHOD_TO(AuthController::totpVerify, "/api/auth/totp/verify", drogon::Post, "AuthFilter");
+    ADD_METHOD_TO(AuthController::totpDisable, "/api/auth/totp/disable", drogon::Post, "AuthFilter");
+    ADD_METHOD_TO(AuthController::backupCodes, "/api/auth/backup-codes", drogon::Post, "AuthFilter");
     METHOD_LIST_END
 
     void registerUser(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
     void login(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
     void logout(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void refresh(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void forgotPassword(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void resetPassword(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void verifyEmail(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void jwks(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void totpEnable(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void totpVerify(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void totpDisable(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void backupCodes(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
 };

--- a/src/controllers/UserController.cc
+++ b/src/controllers/UserController.cc
@@ -1,23 +1,91 @@
 #include "UserController.h"
 #include <drogon/drogon.h>
 #include "../db/SurrealClient.h"
+#include "../utils/crypto.hpp"
+#include "../utils/logging.hpp"
+#include <chrono>
+#include <sstream>
+#include <optional>
+#include <iomanip>
+#include <algorithm>
+#include <memory>
 
 using namespace drogon;
 
-static bool isAdminClaims(const Json::Value& claims) {
-    return claims.get("role","user").asString() == "admin";
+namespace {
+bool isAdminClaims(const Json::Value& claims) {
+    return claims.get("role", "user").asString() == "admin";
 }
+
+Json::Value sanitize(const Json::Value& user) {
+    Json::Value copy = user;
+    copy.removeMember("password_hash");
+    copy.removeMember("totp_secret");
+    copy.removeMember("backup_codes");
+    return copy;
+}
+
+std::string recordIdPart(const std::string& rid) {
+    auto pos = rid.find(':');
+    if (pos == std::string::npos) {
+        return rid;
+    }
+    return rid.substr(pos + 1);
+}
+
+std::string isoNow() {
+    auto now = std::chrono::system_clock::now();
+    auto tt = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#if defined(_WIN32)
+    gmtime_s(&tm, &tt);
+#else
+    gmtime_r(&tt, &tm);
+#endif
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+    return oss.str();
+}
+
+void audit(SurrealClient& db,
+           const Json::Value& claims,
+           const std::string& action,
+           const std::string& resourceType,
+           const std::string& resourceId,
+           const Json::Value& meta = Json::Value(Json::objectValue)) {
+    auto actor = claims.get("sub", "").asString();
+    db.recordAudit(actor.empty() ? "system" : actor, action, resourceType, resourceId, meta);
+}
+
+void invalidateCache(const std::string& userId) {
+    auto redis = app().getRedisClient();
+    redis->execCommandAsync(
+        [](const drogon::nosql::RedisResult &) {},
+        [](const std::exception &) {},
+        "DEL cache:user:%s", userId.c_str());
+}
+
+std::string methodName(const HttpRequestPtr& req) {
+    switch (req->getMethod()) {
+        case Get: return "GET";
+        case Post: return "POST";
+        case Patch: return "PATCH";
+        case Delete: return "DELETE";
+        case Put: return "PUT";
+        default: return "NONE";
+    }
+}
+
+} // namespace
 
 void UserController::me(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) {
     auto attrs = req->getAttributes();
     Json::Value claims = attrs->get<Json::Value>("claims");
-    // Try cached profile
     auto redis = app().getRedisClient();
-    auto uid = claims.get("sub","").asString();
+    auto uid = claims.get("sub", "").asString();
     redis->execCommandAsync(
         [callback, uid](const drogon::nosql::RedisResult &r){
             if (r.type() != drogon::nosql::RedisResultType::kNil) {
-                // cached JSON
                 Json::Value user;
                 Json::CharReaderBuilder rb;
                 std::string errs;
@@ -27,56 +95,269 @@ void UserController::me(const HttpRequestPtr& req, std::function<void (const Htt
                     Json::Value out;
                     out["user"] = user;
                     auto resp = HttpResponse::newHttpJsonResponse(out);
-                    return callback(resp);
+                    callback(resp);
+                    return;
                 }
             }
-            // not cached -> fetch from DB by email
             try {
                 SurrealClient db;
-                // we only stored email in claims; reselect by email
-                auto email = claims.get("email","").asString();
+                auto email = claims.get("email", "").asString();
                 auto user = db.selectOneByEmail(email);
                 Json::Value out;
-                out["user"] = user;
+                out["user"] = sanitize(user);
                 auto resp = HttpResponse::newHttpJsonResponse(out);
                 callback(resp);
-                // set cache async (no wait)
                 app().getRedisClient()->execCommandAsync(
                     [](const drogon::nosql::RedisResult &){},
-                    [](const std::exception &){}, 
+                    [](const std::exception &){},
                     "SETEX cache:user:%s %d %s",
-                    uid.c_str(), 300, drogon::utils::toString(user).c_str());
+                    uid.c_str(), 300, drogon::utils::toString(sanitize(user)).c_str());
             } catch (...) {
-                auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","lookup failed"} });
+                auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "lookup failed"}});
                 resp->setStatusCode(k500InternalServerError);
                 callback(resp);
             }
         },
-        [callback](const std::exception &e){
-            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","redis error"} });
+        [callback](const std::exception &){
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "redis error"}});
             resp->setStatusCode(k500InternalServerError);
             callback(resp);
         },
         "GET cache:user:%s", uid.c_str());
 }
 
+void UserController::updateMe(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) {
+    auto json = req->getJsonObject();
+    if (!json) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid json"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+    auto attrs = req->getAttributes();
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    Json::Value update(Json::objectValue);
+    if ((*json).isMember("name")) update["name"] = (*json)["name"];
+    if ((*json).isMember("avatar")) update["avatar"] = (*json)["avatar"];
+    if ((*json).isMember("preferences")) update["preferences"] = (*json)["preferences"];
+    if (update.empty()) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "no changes"}});
+        return callback(resp);
+    }
+    update["profile_updated_at"] = isoNow();
+    try {
+        SurrealClient db;
+        db.updateRecord("user", recordIdPart(claims.get("sub", "").asString()), update);
+        invalidateCache(claims.get("sub", "").asString());
+        audit(db, claims, "profile_update", "user", claims.get("sub", "").asString(), update);
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("UserController.cc", "UserController", "updateMe", "user", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "update failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void UserController::changePassword(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) {
+    auto json = req->getJsonObject();
+    if (!json || !(*json).isMember("current") || !(*json).isMember("next")) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "current and next required"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+    auto current = (*json)["current"].asString();
+    auto next = (*json)["next"].asString();
+    if (next.size() < 8) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "password too short"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+    auto attrs = req->getAttributes();
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    try {
+        SurrealClient db;
+        auto user = db.selectById("user", recordIdPart(claims.get("sub", "").asString()));
+        if (user.isNull() || !crypto::verify_password_pbkdf2(current, user.get("password_hash", "").asString())) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid password"}});
+            resp->setStatusCode(k401Unauthorized);
+            return callback(resp);
+        }
+        Json::Value update;
+        update["password_hash"] = crypto::hash_password_pbkdf2(next);
+        update["profile_updated_at"] = isoNow();
+        db.updateRecord("user", recordIdPart(user["id"].asString()), update);
+        invalidateCache(claims.get("sub", "").asString());
+        audit(db, claims, "password_change", "user", user["id"].asString(), Json::Value());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("UserController.cc", "UserController", "changePassword", "user", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "change failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
 void UserController::listUsers(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) {
     auto attrs = req->getAttributes();
     Json::Value claims = attrs->get<Json::Value>("claims");
     if (!isAdminClaims(claims)) {
-        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","forbidden"} });
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "forbidden"}});
         resp->setStatusCode(k403Forbidden);
         return callback(resp);
     }
     try {
         SurrealClient db;
-        auto res = db.exec("SELECT id, email, role, created_at, updated_at FROM user ORDER BY created_at DESC LIMIT 100;");
+        auto res = db.exec("SELECT id, email, name, role, status, created_at, updated_at FROM user WHERE deleted_at = NONE OR deleted_at = NULL ORDER BY created_at DESC LIMIT 200;");
         Json::Value out;
         out["result_sets"] = res;
         auto resp = HttpResponse::newHttpJsonResponse(out);
         callback(resp);
-    } catch (...) {
-        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{ {"error","query failed"} });
+    } catch (const std::exception& e) {
+        logging::error("UserController.cc", "UserController", "listUsers", "user", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "query failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void UserController::getUser(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback, std::string userId) {
+    auto attrs = req->getAttributes();
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    if (!isAdminClaims(claims)) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "forbidden"}});
+        resp->setStatusCode(k403Forbidden);
+        return callback(resp);
+    }
+    try {
+        SurrealClient db;
+        auto user = db.selectById("user", userId);
+        if (user.isNull()) {
+            auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "not found"}});
+            resp->setStatusCode(k404NotFound);
+            return callback(resp);
+        }
+        Json::Value out;
+        out["user"] = sanitize(user);
+        auto resp = HttpResponse::newHttpJsonResponse(out);
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("UserController.cc", "UserController", "getUser", "user", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void UserController::updateUser(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback, std::string userId) {
+    auto attrs = req->getAttributes();
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    if (!isAdminClaims(claims)) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "forbidden"}});
+        resp->setStatusCode(k403Forbidden);
+        return callback(resp);
+    }
+    auto json = req->getJsonObject();
+    if (!json) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invalid json"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+    Json::Value update(Json::objectValue);
+    if ((*json).isMember("role")) update["role"] = (*json)["role"];
+    if ((*json).isMember("status")) update["status"] = (*json)["status"];
+    if (update.empty()) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "no changes"}});
+        return callback(resp);
+    }
+    if (update.isMember("status") && update["status"].asString() == "disabled") {
+        update["deleted_at"] = isoNow();
+    }
+    try {
+        SurrealClient db;
+        db.updateRecord("user", userId, update);
+        invalidateCache("user:" + userId);
+        audit(db, claims, "admin_user_update", "user", "user:" + userId, update);
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"status", "ok"}});
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("UserController.cc", "UserController", "updateUser", "user", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "update failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void UserController::deleteUser(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback, std::string userId) {
+    auto attrs = req->getAttributes();
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    if (!isAdminClaims(claims)) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "forbidden"}});
+        resp->setStatusCode(k403Forbidden);
+        return callback(resp);
+    }
+    try {
+        SurrealClient db;
+        Json::Value update;
+        update["status"] = "disabled";
+        update["deleted_at"] = isoNow();
+        db.updateRecord("user", userId, update);
+        invalidateCache("user:" + userId);
+        audit(db, claims, "admin_user_delete", "user", "user:" + userId, Json::Value());
+        auto resp = HttpResponse::newHttpResponse();
+        resp->setStatusCode(k204NoContent);
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("UserController.cc", "UserController", "deleteUser", "user", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "delete failed"}});
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    }
+}
+
+void UserController::bulkInvite(const HttpRequestPtr& req, std::function<void (const HttpResponsePtr &)> &&callback) {
+    auto attrs = req->getAttributes();
+    Json::Value claims = attrs->get<Json::Value>("claims");
+    if (!isAdminClaims(claims)) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "forbidden"}});
+        resp->setStatusCode(k403Forbidden);
+        return callback(resp);
+    }
+    auto json = req->getJsonObject();
+    if (!json || !(*json).isMember("emails") || !(*json)["emails"].isArray()) {
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "emails array required"}});
+        resp->setStatusCode(k400BadRequest);
+        return callback(resp);
+    }
+    try {
+        SurrealClient db;
+        Json::Value created(Json::arrayValue);
+        for (const auto& emailVal : (*json)["emails"]) {
+            auto email = emailVal.asString();
+            if (email.empty()) continue;
+            auto normalized = email;
+            std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char c){ return std::tolower(c); });
+            auto token = crypto::random_token_hex(16);
+            Json::Value invite;
+            invite["email"] = normalized;
+            invite["invited_by"] = claims.get("sub", "").asString();
+            invite["token_hash"] = crypto::sha256_hex(token);
+            invite["status"] = "pending";
+            db.createRecord("invite", drogon::utils::getUuid(), invite);
+            Json::Value item;
+            item["email"] = normalized;
+            item["token"] = token;
+            created.append(item);
+        }
+        audit(db, claims, "bulk_invite", "invite", "batch", Json::Value{{"count", static_cast<Json::Int64>(created.size())}});
+        Json::Value out;
+        out["invites"] = created;
+        auto resp = HttpResponse::newHttpJsonResponse(out);
+        callback(resp);
+    } catch (const std::exception& e) {
+        logging::error("UserController.cc", "UserController", "bulkInvite", "user", __LINE__, e.what(), methodName(req), e.what());
+        auto resp = HttpResponse::newHttpJsonResponse(Json::Value{{"error", "invite failed"}});
         resp->setStatusCode(k500InternalServerError);
         callback(resp);
     }

--- a/src/controllers/UserController.h
+++ b/src/controllers/UserController.h
@@ -5,9 +5,21 @@ class UserController : public drogon::HttpController<UserController> {
 public:
     METHOD_LIST_BEGIN
     ADD_METHOD_TO(UserController::me, "/api/me", drogon::Get, "AuthFilter");
+    ADD_METHOD_TO(UserController::updateMe, "/api/me", drogon::Patch, "AuthFilter");
+    ADD_METHOD_TO(UserController::changePassword, "/api/me/password", drogon::Patch, "AuthFilter");
     ADD_METHOD_TO(UserController::listUsers, "/api/users", drogon::Get, "AuthFilter");
+    ADD_METHOD_TO(UserController::getUser, "/api/users/{1}", drogon::Get, "AuthFilter");
+    ADD_METHOD_TO(UserController::updateUser, "/api/users/{1}", drogon::Patch, "AuthFilter");
+    ADD_METHOD_TO(UserController::deleteUser, "/api/users/{1}", drogon::Delete, "AuthFilter");
+    ADD_METHOD_TO(UserController::bulkInvite, "/api/users/bulk-invite", drogon::Post, "AuthFilter");
     METHOD_LIST_END
 
     void me(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void updateMe(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void changePassword(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
     void listUsers(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
+    void getUser(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback, std::string userId);
+    void updateUser(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback, std::string userId);
+    void deleteUser(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback, std::string userId);
+    void bulkInvite(const drogon::HttpRequestPtr& req, std::function<void (const drogon::HttpResponsePtr &)> &&callback);
 };

--- a/src/db/SurrealClient.cc
+++ b/src/db/SurrealClient.cc
@@ -3,6 +3,7 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
+#include <stdexcept>
 
 using namespace drogon;
 
@@ -83,4 +84,71 @@ Json::Value SurrealClient::createUser(const std::string& email, const std::strin
         return res[0]["result"][0];
     }
     throw std::runtime_error("Failed to create user");
+}
+
+Json::Value SurrealClient::firstResult(const Json::Value& res) const {
+    if (res.isArray() && !res.empty()) {
+        const auto& item = res[0];
+        if (item.isMember("result") && item["result"].isArray() && !item["result"].empty()) {
+            return item["result"][0];
+        }
+    }
+    return Json::Value(Json::nullValue);
+}
+
+std::string SurrealClient::toJsonString(const Json::Value& value) const {
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    return Json::writeString(builder, value);
+}
+
+Json::Value SurrealClient::selectById(const std::string& table, const std::string& id) {
+    if (id.find('"') != std::string::npos || id.find('\'') != std::string::npos || id.find(';') != std::string::npos) {
+        throw std::runtime_error("invalid id characters");
+    }
+    std::stringstream ss;
+    ss << "SELECT * FROM " << table << ":" << id << " LIMIT 1;";
+    auto res = exec(ss.str());
+    return firstResult(res);
+}
+
+Json::Value SurrealClient::createRecord(const std::string& table, const std::string& id, const Json::Value& content) {
+    if (id.find('"') != std::string::npos || id.find('\'') != std::string::npos || id.find(';') != std::string::npos) {
+        throw std::runtime_error("invalid id characters");
+    }
+    std::stringstream ss;
+    ss << "CREATE " << table << ":" << id << " CONTENT " << toJsonString(content) << ";";
+    auto res = exec(ss.str());
+    return firstResult(res);
+}
+
+Json::Value SurrealClient::updateRecord(const std::string& table, const std::string& id, const Json::Value& content) {
+    if (id.find('"') != std::string::npos || id.find('\'') != std::string::npos || id.find(';') != std::string::npos) {
+        throw std::runtime_error("invalid id characters");
+    }
+    std::stringstream ss;
+    ss << "UPDATE " << table << ":" << id << " MERGE " << toJsonString(content) << ";";
+    auto res = exec(ss.str());
+    return firstResult(res);
+}
+
+void SurrealClient::recordAudit(const std::string& userId,
+                                const std::string& action,
+                                const std::string& resourceType,
+                                const std::string& resourceId,
+                                const Json::Value& metadata) {
+    Json::Value payload;
+    payload["user_id"] = userId;
+    payload["action"] = action;
+    payload["resource_type"] = resourceType;
+    payload["resource_id"] = resourceId;
+    payload["metadata"] = metadata;
+    payload["created_at"] = "time::now()";
+    // created_at should be set by Surreal; but to keep time format, use expression via query
+    std::stringstream ss;
+    Json::Value withoutTime = payload;
+    withoutTime.removeMember("created_at");
+    ss << "LET $payload = " << toJsonString(withoutTime) << ";";
+    ss << "CREATE audit_log CONTENT merge($payload, { created_at: time::now() });";
+    exec(ss.str());
 }

--- a/src/db/SurrealClient.h
+++ b/src/db/SurrealClient.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <drogon/drogon.h>
+#include <json/value.h>
+#include <json/writer.h>
 
 class SurrealClient {
 public:
@@ -13,10 +15,21 @@ public:
     Json::Value selectOneByEmail(const std::string& emailNorm);
     Json::Value createUser(const std::string& email, const std::string& emailNorm,
                            const std::string& passwordHash, const std::string& role);
+    Json::Value selectById(const std::string& table, const std::string& id);
+    Json::Value createRecord(const std::string& table, const std::string& id, const Json::Value& content);
+    Json::Value updateRecord(const std::string& table, const std::string& id, const Json::Value& content);
+    void recordAudit(const std::string& userId,
+                     const std::string& action,
+                     const std::string& resourceType,
+                     const std::string& resourceId,
+                     const Json::Value& metadata);
+    Json::Value firstResult(const Json::Value& resultSets) const;
 
 private:
     drogon::HttpClientPtr client_;
     std::string ns_;
     std::string db_;
     std::string basicAuth_;
+
+    std::string toJsonString(const Json::Value& value) const;
 };

--- a/src/utils/crypto.hpp
+++ b/src/utils/crypto.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <stdexcept>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <sstream>
@@ -24,6 +25,41 @@ inline std::vector<unsigned char> from_hex(const std::string& s) {
 }
 
 inline void random_bytes(unsigned char* buf, size_t n) { RAND_bytes(buf, (int)n); }
+
+inline std::string sha256_hex(const std::string& data) {
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    if (!ctx) {
+        throw std::runtime_error("EVP_MD_CTX_new failed");
+    }
+    std::vector<unsigned char> hash(EVP_MAX_MD_SIZE);
+    unsigned int len = 0;
+    if (EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr) != 1 ||
+        EVP_DigestUpdate(ctx, data.data(), data.size()) != 1 ||
+        EVP_DigestFinal_ex(ctx, hash.data(), &len) != 1) {
+        EVP_MD_CTX_free(ctx);
+        throw std::runtime_error("sha256 computation failed");
+    }
+    EVP_MD_CTX_free(ctx);
+    return to_hex(std::vector<unsigned char>(hash.begin(), hash.begin() + len));
+}
+
+inline std::string random_token_hex(size_t bytes = 32) {
+    std::vector<unsigned char> buf(bytes);
+    random_bytes(buf.data(), buf.size());
+    return to_hex(buf);
+}
+
+inline std::string random_alphanum(size_t length) {
+    static const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    std::vector<unsigned char> buf(length);
+    random_bytes(buf.data(), buf.size());
+    std::string out;
+    out.reserve(length);
+    for (auto b : buf) {
+        out.push_back(alphabet[b % (sizeof(alphabet) - 1)]);
+    }
+    return out;
+}
 
 inline std::string hash_password_pbkdf2(const std::string& password, int iterations = 150000) {
     unsigned char salt[16];

--- a/src/utils/logging.hpp
+++ b/src/utils/logging.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <drogon/drogon.h>
+#include <json/value.h>
+#include <json/writer.h>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <iostream>
+
+namespace logging {
+
+inline std::string iso_timestamp() {
+    auto now = std::chrono::system_clock::now();
+    auto tt = std::chrono::system_clock::to_time_t(now);
+    auto tm = *std::gmtime(&tt);
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+    return oss.str();
+}
+
+inline void log(const std::string& level,
+                const std::string& filename,
+                const std::string& classname,
+                const std::string& function,
+                const std::string& system_section,
+                int line,
+                const std::string& message,
+                const std::string& method = "NONE",
+                const std::string& error = "",
+                const std::string& db_phase = "none") {
+    Json::Value event;
+    event["level"] = level;
+    event["filename"] = filename;
+    event["timestamp"] = iso_timestamp();
+    event["classname"] = classname;
+    event["function"] = function;
+    event["system_section"] = system_section;
+    event["line_num"] = line;
+    event["error"] = error;
+    event["db_phase"] = db_phase;
+    event["method"] = method;
+    event["message"] = message;
+    Json::StreamWriterBuilder builder;
+    builder["indentation"] = "";
+    std::cout << Json::writeString(builder, event) << std::endl;
+    std::cout << "[The 17 Commandments of Quality Code] " << message << std::endl;
+}
+
+inline void info(const std::string& filename,
+                 const std::string& classname,
+                 const std::string& function,
+                 const std::string& system_section,
+                 int line,
+                 const std::string& message,
+                 const std::string& method = "NONE") {
+    log("INFO", filename, classname, function, system_section, line, message, method);
+}
+
+inline void warn(const std::string& filename,
+                 const std::string& classname,
+                 const std::string& function,
+                 const std::string& system_section,
+                 int line,
+                 const std::string& message,
+                 const std::string& method = "NONE",
+                 const std::string& error = "") {
+    log("WARN", filename, classname, function, system_section, line, message, method, error);
+}
+
+inline void error(const std::string& filename,
+                  const std::string& classname,
+                  const std::string& function,
+                  const std::string& system_section,
+                  int line,
+                  const std::string& message,
+                  const std::string& method = "NONE",
+                  const std::string& error = "") {
+    log("ERROR", filename, classname, function, system_section, line, message, method, error);
+}
+
+} // namespace logging

--- a/src/utils/totp.hpp
+++ b/src/utils/totp.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "crypto.hpp"
+#include <openssl/hmac.h>
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <sstream>
+#include <iomanip>
+#include <drogon/utils/Utilities.h>
+
+namespace totp {
+
+inline std::string base32_encode(const std::vector<unsigned char>& data) {
+    static const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    std::string out;
+    size_t i = 0;
+    int current = 0;
+    int bits = 0;
+    while (i < data.size()) {
+        current = (current << 8) | data[i++];
+        bits += 8;
+        while (bits >= 5) {
+            int index = (current >> (bits - 5)) & 0x1F;
+            out.push_back(alphabet[index]);
+            bits -= 5;
+        }
+    }
+    if (bits > 0) {
+        int index = (current << (5 - bits)) & 0x1F;
+        out.push_back(alphabet[index]);
+    }
+    while (out.size() % 8 != 0) {
+        out.push_back('=');
+    }
+    return out;
+}
+
+inline std::vector<unsigned char> base32_decode(const std::string& input) {
+    static const std::string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    std::vector<unsigned char> out;
+    int buffer = 0;
+    int bits = 0;
+    for (char c : input) {
+        if (c == '=') break;
+        char up = std::toupper(static_cast<unsigned char>(c));
+        auto pos = alphabet.find(up);
+        if (pos == std::string::npos) {
+            throw std::runtime_error("invalid base32 character");
+        }
+        buffer = (buffer << 5) | static_cast<int>(pos);
+        bits += 5;
+        if (bits >= 8) {
+            int shift = bits - 8;
+            out.push_back(static_cast<unsigned char>((buffer >> shift) & 0xFF));
+            bits -= 8;
+            buffer &= (1 << bits) - 1;
+        }
+    }
+    return out;
+}
+
+inline std::string generate_secret(size_t bytes = 20) {
+    std::vector<unsigned char> buf(bytes);
+    crypto::random_bytes(buf.data(), buf.size());
+    return base32_encode(buf);
+}
+
+inline uint32_t compute_code(const std::vector<unsigned char>& key, uint64_t counter) {
+    unsigned char counter_bytes[8];
+    for (int i = 7; i >= 0; --i) {
+        counter_bytes[i] = static_cast<unsigned char>(counter & 0xFF);
+        counter >>= 8;
+    }
+    unsigned int len = 0;
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    if (!HMAC(EVP_sha1(), key.data(), static_cast<int>(key.size()), counter_bytes, sizeof(counter_bytes), digest, &len)) {
+        throw std::runtime_error("HMAC failed");
+    }
+    int offset = digest[len - 1] & 0x0F;
+    uint32_t binary = ((digest[offset] & 0x7F) << 24) |
+                      ((digest[offset + 1] & 0xFF) << 16) |
+                      ((digest[offset + 2] & 0xFF) << 8) |
+                      (digest[offset + 3] & 0xFF);
+    return binary % 1000000;
+}
+
+inline bool verify_code(const std::string& secret, const std::string& code, int window = 1, int digits = 6, int period = 30) {
+    if (code.size() != static_cast<size_t>(digits)) {
+        return false;
+    }
+    for (char c : code) {
+        if (!std::isdigit(static_cast<unsigned char>(c))) {
+            return false;
+        }
+    }
+    auto key = base32_decode(secret);
+    auto now = std::chrono::system_clock::now();
+    auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+    uint64_t current_counter = static_cast<uint64_t>(seconds) / period;
+    uint32_t target = static_cast<uint32_t>(std::stoul(code));
+    for (int i = -window; i <= window; ++i) {
+        uint64_t counter = current_counter + i;
+        uint32_t candidate = compute_code(key, counter);
+        if (candidate == target) {
+            return true;
+        }
+    }
+    return false;
+}
+
+inline std::string otpauth_uri(const std::string& issuer, const std::string& accountName, const std::string& secret) {
+    std::string label = drogon::utils::urlEncode(issuer + ":" + accountName);
+    std::string encIssuer = drogon::utils::urlEncode(issuer);
+    return "otpauth://totp/" + label + "?secret=" + secret + "&issuer=" + encIssuer + "&algorithm=SHA1&digits=6&period=30";
+}
+
+inline std::string generate_code_now(const std::string& secret, int period = 30) {
+    auto key = base32_decode(secret);
+    auto now = std::chrono::system_clock::now();
+    auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+    uint32_t code = compute_code(key, static_cast<uint64_t>(seconds) / period);
+    std::ostringstream oss;
+    oss << std::setw(6) << std::setfill('0') << code;
+    return oss.str();
+}
+
+} // namespace totp


### PR DESCRIPTION
## Summary
- expand the authentication controller to support refresh token rotation, password reset and email verification flows, JWKS exposure, and full TOTP enrollment including backup codes
- add reusable structured logging and TOTP helpers, extend the SurrealDB client utilities, and define schema migrations for roles, sessions, organizations, projects, tokens, and related tables
- enhance the user controller with profile updates, password changes, admin CRUD endpoints, and bulk invitation generation backed by audit logging and cache invalidation

## Testing
- `cmake -S . -B build` *(fails: Drogon package configuration is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7bd73a14832bb83604008107bbe6