### PR TITLE
Add gRPC user service support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,62 @@
+
 cmake_minimum_required(VERSION 3.16)
 project(drgn_surreal_starter LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find Drogon (installed via package manager or built from source)
+if(NOT MYSQL_INCLUDE_DIRS)
+    set(MYSQL_INCLUDE_DIRS "/usr/include/mysql" CACHE PATH "MySQL include dir")
+endif()
+if(NOT MYSQL_LIBRARIES)
+    set(MYSQL_LIBRARIES "/usr/lib/x86_64-linux-gnu/libmysqlclient.so" CACHE FILEPATH "MySQL client library")
+endif()
+
+
 find_package(Drogon CONFIG REQUIRED)
-# OpenSSL for HMAC/PBKDF2
 find_package(OpenSSL REQUIRED)
+find_package(Protobuf REQUIRED)
+find_package(c-ares CONFIG REQUIRED)
+find_package(gRPC CONFIG REQUIRED)
+find_program(GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin REQUIRED)
+
+set(PROTO_SRC ${CMAKE_CURRENT_SOURCE_DIR}/proto/user.proto)
+set(GRPC_GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
+file(MAKE_DIRECTORY ${GRPC_GENERATED_DIR})
+
+add_custom_command(
+    OUTPUT
+        ${GRPC_GENERATED_DIR}/user.pb.cc
+        ${GRPC_GENERATED_DIR}/user.pb.h
+        ${GRPC_GENERATED_DIR}/user.grpc.pb.cc
+        ${GRPC_GENERATED_DIR}/user.grpc.pb.h
+    COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+    ARGS --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/proto
+         --cpp_out=${GRPC_GENERATED_DIR}
+         --grpc_out=${GRPC_GENERATED_DIR}
+         --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_EXECUTABLE}
+         ${PROTO_SRC}
+    DEPENDS ${PROTO_SRC}
+    COMMENT "Generating gRPC sources"
+    VERBATIM
+)
+
+add_custom_target(generate_grpc_user
+    DEPENDS
+        ${GRPC_GENERATED_DIR}/user.pb.cc
+        ${GRPC_GENERATED_DIR}/user.pb.h
+        ${GRPC_GENERATED_DIR}/user.grpc.pb.cc
+        ${GRPC_GENERATED_DIR}/user.grpc.pb.h
+)
+
+
+add_library(grpc_user_proto STATIC
+    ${GRPC_GENERATED_DIR}/user.pb.cc
+    ${GRPC_GENERATED_DIR}/user.grpc.pb.cc
+)
+add_dependencies(grpc_user_proto generate_grpc_user)
+target_include_directories(grpc_user_proto PUBLIC ${GRPC_GENERATED_DIR})
+target_link_libraries(grpc_user_proto PUBLIC gRPC::grpc++ protobuf::libprotobuf)
 
 add_executable(drgn_surreal
     src/main.cc
@@ -15,12 +64,17 @@ add_executable(drgn_surreal
     src/filters/AuthFilter.cc
     src/controllers/AuthController.cc
     src/controllers/UserController.cc
+    src/grpc/UserServiceImpl.cc
 )
+add_dependencies(drgn_surreal generate_grpc_user)
 
-target_include_directories(drgn_surreal PRIVATE ${OPENSSL_INCLUDE_DIR})
-target_link_libraries(drgn_surreal PRIVATE Drogon::Drogon OpenSSL::SSL OpenSSL::Crypto)
+target_include_directories(drgn_surreal
+    PRIVATE
+        ${OPENSSL_INCLUDE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+target_link_libraries(drgn_surreal PRIVATE Drogon::Drogon OpenSSL::SSL OpenSSL::Crypto grpc_user_proto)
 
-# On macOS, rpath for Drogon if installed via brew/vcpkg
 if(APPLE)
     set_target_properties(drgn_surreal PROPERTIES
         BUILD_WITH_INSTALL_RPATH TRUE

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ curl -X POST http://localhost:8080/api/auth/register \
   -d '{"email":"admin@example.com","password":"secret"}'
 ```
 
+
+## gRPC API
+
+- Service: `dragonbreath.grpc.UserService` listening on port `50051` by default.
+- `GetUser(GetUserRequest)` → returns a sanitized user profile (`id`, `email`, `role`, timestamps).
+
+Example using [grpcurl](https://github.com/fullstorydev/grpcurl):
+
+```bash
+grpcurl -plaintext -d '{"id":"user:01H..."}' localhost:50051 dragonbreath.grpc.UserService/GetUser
+```
+
+Configure the listener with `GRPC_LISTEN_ADDR` (defaults to `0.0.0.0:50051`).
+
 ## Config
 
 See `config/config.json`. Override via env vars for Surreal, Redis, JWT secret.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,10 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_DB: 0
+      GRPC_LISTEN_ADDR: 0.0.0.0:50051
     ports:
       - "8080:8080"
+      - "50051:50051"
     command: ["/srv/drgn_surreal", "--config=/srv/config.json"]
 
 volumes:

--- a/proto/user.proto
+++ b/proto/user.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package dragonbreath.grpc;
+
+message GetUserRequest {
+  string id = 1;
+}
+
+message UserProfile {
+  string id = 1;
+  string email = 2;
+  string role = 3;
+  string created_at = 4;
+  string updated_at = 5;
+}
+
+message GetUserResponse {
+  UserProfile user = 1;
+}
+
+service UserService {
+  rpc GetUser(GetUserRequest) returns (GetUserResponse);
+}

--- a/src/grpc/UserServiceImpl.cc
+++ b/src/grpc/UserServiceImpl.cc
@@ -1,0 +1,83 @@
+
+#include "UserServiceImpl.h"
+
+#include "../db/SurrealClient.h"
+#include "../utils/logging.hpp"
+
+#include <json/value.h>
+#include <json/writer.h>
+
+#include <stdexcept>
+#include <string>
+
+using dragonbreath::grpc::GetUserRequest;
+using dragonbreath::grpc::GetUserResponse;
+using dragonbreath::grpc::UserProfile;
+
+namespace {
+std::string recordId(const Json::Value& user) {
+    if (!user.isMember("id")) {
+        return "";
+    }
+    return user["id"].asString();
+}
+
+std::string stringField(const Json::Value& value, const std::string& key) {
+    if (!value.isMember(key)) {
+        return "";
+    }
+    const auto& field = value[key];
+    if (field.isString()) {
+        return field.asString();
+    }
+    if (field.isNumeric()) {
+        return field.asString();
+    }
+    if (!field.isNull()) {
+        Json::StreamWriterBuilder builder;
+        builder["indentation"] = "";
+        return Json::writeString(builder, field);
+    }
+    return "";
+}
+}
+
+grpc::Status UserServiceImpl::GetUser(::grpc::ServerContext* context,
+                                      const GetUserRequest* request,
+                                      GetUserResponse* response) {
+    const std::string peer = context ? context->peer() : "";
+    const std::string methodTag = "UserService.GetUser";
+    logging::info("UserServiceImpl.cc", "UserServiceImpl", "GetUser", "grpc", __LINE__,
+                  "incoming GetUser request from " + peer, methodTag);
+
+    if (!request || request->id().empty()) {
+        logging::warn("UserServiceImpl.cc", "UserServiceImpl", "GetUser", "grpc", __LINE__,
+                      "missing id in GetUser request from " + peer, methodTag, "id is required");
+        return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, "id is required");
+    }
+
+    try {
+        SurrealClient db;
+        auto user = db.selectById("user", request->id());
+        if (user.isNull() || !user.isMember("id")) {
+            logging::warn("UserServiceImpl.cc", "UserServiceImpl", "GetUser", "grpc", __LINE__,
+                          "user not found for peer " + peer, methodTag, "user not found");
+            return grpc::Status(grpc::StatusCode::NOT_FOUND, "user not found");
+        }
+
+        UserProfile* profile = response->mutable_user();
+        profile->set_id(recordId(user));
+        profile->set_email(stringField(user, "email"));
+        profile->set_role(stringField(user, "role"));
+        profile->set_created_at(stringField(user, "created_at"));
+        profile->set_updated_at(stringField(user, "updated_at"));
+
+        logging::info("UserServiceImpl.cc", "UserServiceImpl", "GetUser", "grpc", __LINE__,
+                      "user loaded successfully for peer " + peer, methodTag);
+        return grpc::Status::OK;
+    } catch (const std::exception& ex) {
+        logging::error("UserServiceImpl.cc", "UserServiceImpl", "GetUser", "grpc", __LINE__,
+                       "exception while fetching user for peer " + peer, methodTag, ex.what());
+        return grpc::Status(grpc::StatusCode::INTERNAL, ex.what());
+    }
+}

--- a/src/grpc/UserServiceImpl.h
+++ b/src/grpc/UserServiceImpl.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <grpcpp/grpcpp.h>
+#include "user.grpc.pb.h"
+
+class UserServiceImpl final : public dragonbreath::grpc::UserService::Service {
+public:
+    grpc::Status GetUser(::grpc::ServerContext* context,
+                         const dragonbreath::grpc::GetUserRequest* request,
+                         dragonbreath::grpc::GetUserResponse* response) override;
+};

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,28 +1,62 @@
+
 #include <drogon/drogon.h>
 #include <cstdlib>
+#include <memory>
 #include <string>
+#include <thread>
+
+#include <grpcpp/grpcpp.h>
+
+#include "grpc/UserServiceImpl.h"
+#include "utils/logging.hpp"
 
 int main(int argc, char* argv[]) {
     using namespace drogon;
 
-    // Load config if provided via --config
+    std::string grpcAddress = "0.0.0.0:50051";
+    if (const char* envAddr = std::getenv("GRPC_LISTEN_ADDR")) {
+        if (*envAddr != '\0') {
+            grpcAddress = envAddr;
+        }
+    }
+
+    UserServiceImpl userService;
+    grpc::ServerBuilder grpcBuilder;
+    grpcBuilder.AddListeningPort(grpcAddress, grpc::InsecureServerCredentials());
+    grpcBuilder.RegisterService(&userService);
+    std::unique_ptr<grpc::Server> grpcServer(grpcBuilder.BuildAndStart());
+    if (!grpcServer) {
+        logging::error("main.cc", "main", "main", "grpc", __LINE__,
+                       "Failed to start gRPC server on " + grpcAddress, "UserService.GetUser");
+        return EXIT_FAILURE;
+    }
+
+    logging::info("main.cc", "main", "main", "grpc", __LINE__,
+                  "gRPC server listening on " + grpcAddress, "UserService.GetUser");
+    std::thread grpcThread([serverPtr = grpcServer.get()]() {
+        serverPtr->Wait();
+    });
+
     app().addListener("0.0.0.0", 8080);
 
-    // Basic CORS for API
     app().registerPostHandlingAdvice([](const HttpRequestPtr& req, const HttpResponsePtr& resp){
         resp->addHeader("Access-Control-Allow-Origin", "*");
         resp->addHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
         resp->addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
     });
 
-    // Simple OPTIONS responder
     app().registerHandler("/{path}", [](const HttpRequestPtr&, std::function<void (const HttpResponsePtr &)> &&callback){
         auto resp = drogon::HttpResponse::newHttpResponse();
         resp->setStatusCode(drogon::k204NoContent);
         callback(resp);
     }, {drogon::Options});
 
-    LOG_INFO << "Starting server...";
+    LOG_INFO << "Starting HTTP server...";
     app().run();
+
+    grpcServer->Shutdown();
+    if (grpcThread.joinable()) {
+        grpcThread.join();
+    }
     return 0;
 }

--- a/task.md
+++ b/task.md
@@ -1,0 +1,8 @@
+
+# Task Tracker
+
+- [x] Review project structure and existing instructions
+- [x] Implement gRPC service for core user data access
+- [x] Update build configuration and dependencies for gRPC
+- [x] Document new gRPC capabilities and usage
+- [ ] Build and test the project after gRPC integration (blocked: Drogon dependency build fails on drogon::utils::escapeHtml with packaged version)


### PR DESCRIPTION
## Summary
- add protobuf definition and service implementation to expose a gRPC UserService alongside the existing HTTP API
- update the build to generate/link protobuf and gRPC artifacts and wire the gRPC server into the Drogon entry point
- document the new gRPC surface, expose the port in docker-compose, and add a lightweight task tracker

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: packaged Drogon headers lack drogon::utils::escapeHtml referenced in existing SurrealClient.cc)*

------
https://chatgpt.com/codex/tasks/task_e_68e09a727990832ba1b9dbca3794f8b0